### PR TITLE
:bug: Fix `Colors` enum declaration

### DIFF
--- a/color.py
+++ b/color.py
@@ -2,7 +2,7 @@ import enum
 import random
 
 
-class Colors(enum.Enum, str):
+class Colors(str, enum.Enum):
     ERROR = '\033[31m', '\033[91m'
     SUCCESS = '\033[32m', '\033[92m'
     WARNING = '\033[33m', '\033[93m'


### PR DESCRIPTION
I faced an error when I tried to use the password generator.
Here's the traceback: `TypeError: new enumerations should be created as `EnumName([mixin_type, ...] [data_type,] enum_type)``

The solution is to declare Colors enumeration in correct inheritance order